### PR TITLE
Removed extra title tag from default layout.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,6 @@
 
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-  <title>{{ page.title }} | {{ site.name }}</title>
   <meta name="viewport" content="width=device-width, minimum-scale=0.5 maximum-scale=1.0">
 
   {% if page.description != nil %}


### PR DESCRIPTION
There were two identical title tags in the default layout. This gets rid of one of them.