### PR TITLE
Correcting my degree name

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -328,7 +328,7 @@
   published: true
   name: greg
   bio: |
-    Greg got his start in web development as a young entrepreneur, focusing on web consulting, hosting, and product development. He has a Master’s degree in Information Technology and is an active volunteer and speaker in the Portland Drupal community. Greg has led the development of numerous, large-scale Drupal web applications, yet he considers his greatest achievement to be his open source contributions to Drupal 8. When he’s not speaking at local Drupal events, or helping nonprofits leverage new technologies, he’s trying to convince himself that he likes chamomile tea. 120 cups in and he’s still not sure if it’ll ever be a taste he acquires. He’s also an avid bicyclist and especially enjoys riding through Portland’s very rare, freak blizzards.
+    Greg got his start in web development as a young entrepreneur, focusing on web consulting, hosting, and product development. He has a Master’s degree in Information Technology Management and is an active volunteer and speaker in the Portland Drupal community. Greg has led the development of numerous, large-scale Drupal web applications, yet he considers his greatest achievement to be his open source contributions to Drupal 8. When he’s not speaking at local Drupal events, or helping nonprofits leverage new technologies, he’s trying to convince himself that he likes chamomile tea. 120 cups in and he’s still not sure if it’ll ever be a taste he acquires. He’s also an avid bicyclist and especially enjoys riding through Portland’s very rare, freak blizzards.
     
 - first_name: Jami
   last_name: Dwyer


### PR DESCRIPTION
The name of my degree was changed when my bio was published because having two ands in a row creates an awkward sentence. Admittedly, my department at Illinois Institute of Technology gives a strange name to their degrees. So, rather than changing the subject of my degree to fit the sentence, I've dropped the extra "and". Suggestions welcome.